### PR TITLE
:bug: Fix href for screenshot

### DIFF
--- a/docs/build/html/index.html
+++ b/docs/build/html/index.html
@@ -105,7 +105,7 @@
 <p><em>PACKAGE UNDER DEVELOPMENT</em></p>
 <p>Full Documentation here: <a class="reference external" href="https://pwildenhain.github.io/TerminalPlayingCards">https://pwildenhain.github.io/TerminalPlayingCards</a></p>
 <p>A little taste 🍰 of what is to come</p>
-<a class="reference external image-reference" href="_static/screenshot.png"><img alt="" src="_images/screenshot.png" /></a>
+<a class="reference external image-reference" href="../../source/_static/screenshot.png"><img alt="" src="_images/screenshot.png" /></a>
 <div class="toctree-wrapper compound">
 </div>
 </div>


### PR DESCRIPTION
Will likely need to write some sort of script at some point that goes through and changes all of these relative `_static` paths